### PR TITLE
Fixing error calling replace on non string

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,8 +102,8 @@ Yuri.prototype.port = function (port) {
 Yuri.prototype.pathname = function (pathname) {
   if (Array.isArray(pathname)) {
     this.url.pathname = pathname.map(function (p, i) {
-      if (i === pathname.length - 1) return p.replace(/^\//, '');
-      return p.replace(/^\/|\/$/g, '');
+      if (i === pathname.length - 1) return p.toString().replace(/^\//, '');
+      return p.toString().replace(/^\/|\/$/g, '');
     }).join('/');
   } else {
     this.url.pathname = pathname;

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,14 @@ describe('Yuri', function () {
     expect(url).to.equal('http://www.zillow.com/one/two/three');
   });
 
+  it('formats pathname with strings and ints', function(){
+    var url = yuri('http://www.zillow.com')
+              .pathname(['1', 'two', 3, '/four'])
+              .format();
+
+    expect(url).to.equal('http://www.zillow.com/1/two/3/four');
+  });
+
   it('formats pathname without double slashes', function () {
     var url = yuri('http://www.zillow.com')
               .pathname(['/one/', '/two/three/four/', '/five/'])


### PR DESCRIPTION
when providing a `pathname` array, if one of the array values is an integer, a TypeError will be thrown:

`TypeError: undefined is not a function`

this is due to the `replace`.  Suggesting to convert to string first
